### PR TITLE
Remove cocos2d folder from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,15 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+#cocos2d-x
+cocos2d/
+libs/
+bin/
+obj/
+assets/
+gen/
+out/
+.classpath
+.project
+.cproject

--- a/cocos2d/.gitignore
+++ b/cocos2d/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
I have added the folder cocos2d to the root .gitignore file so the folder cocos2d is not included in the repository.  Having this folder in the repository makes it uncomfortable to work locally with your preferred cocos2d-x.3.X core source.